### PR TITLE
Make targets an optional argument for generators

### DIFF
--- a/megnet/data/graph.py
+++ b/megnet/data/graph.py
@@ -271,7 +271,10 @@ class BaseGraphBatchGenerator(Sequence):
             batch_size (int): Maximum batch size
             shuffle (bool): Whether to shuffle the data after each step
         """
-        self.targets = np.array(targets)
+        if targets is not None:
+            self.targets = np.array(targets)
+        else:
+            self.targets = None
         self.batch_size = batch_size
         self.total_n = dataset_size
         self.is_shuffle = shuffle
@@ -370,12 +373,16 @@ class BaseGraphBatchGenerator(Sequence):
         # Make the graph data
         inputs = self._combine_graph_data(*inputs)
 
-        # get targets
-        it = itemgetter(*batch_index)
-        target_temp = it(self.targets)
-        target_temp = np.atleast_2d(target_temp)
+        # Return the batch
+        if self.targets is None:
+            return inputs
+        else:
+            # get targets
+            it = itemgetter(*batch_index)
+            target_temp = it(self.targets)
+            target_temp = np.atleast_2d(target_temp)
 
-        return inputs, expand_1st(target_temp)
+            return inputs, expand_1st(target_temp)
 
     @abstractmethod
     def _generate_inputs(self, batch_index):
@@ -418,7 +425,7 @@ class GraphBatchGenerator(BaseGraphBatchGenerator):
                  state_features,
                  index1_list,
                  index2_list,
-                 targets,
+                 targets=None,
                  batch_size=128,
                  is_shuffle=True):
         super().__init__(len(atom_features), targets, batch_size, is_shuffle)
@@ -477,7 +484,7 @@ class GraphBatchDistanceConvert(GraphBatchGenerator):
                  state_features,
                  index1_list,
                  index2_list,
-                 targets,
+                 targets=None,
                  batch_size=128,
                  is_shuffle=True,
                  distance_converter=None):

--- a/megnet/data/molecule.py
+++ b/megnet/data/molecule.py
@@ -501,7 +501,7 @@ class MolecularGraphBatchGenerator(BaseGraphBatchGenerator):
     we recommend using :class:`megnet.data.graph.GraphBatchGenerator` instead to avoid
     the computational cost of dynamically computing graphs."""
 
-    def __init__(self, mols, targets, converter=None, molecule_format='xyz',
+    def __init__(self, mols, targets=None, converter=None, molecule_format='xyz',
                  batch_size=128, shuffle=True, n_jobs=1):
         """
         Args:

--- a/megnet/data/tests/test_graph.py
+++ b/megnet/data/tests/test_graph.py
@@ -1,3 +1,4 @@
+import tensorflow as tf
 import unittest
 from megnet.data.graph import GaussianDistance, GraphBatchGenerator, GraphBatchDistanceConvert, \
     MoorseLongRange
@@ -26,7 +27,8 @@ class TestGraph(unittest.TestCase):
         index1 = [np.array([0, 1]), np.array([0])]
         index2 = [np.array([1, 2]), np.array([1])]
         targets = np.random.normal(size=(2, 1))
-        gen = GraphBatchGenerator(feature, bond, glob_features, index1, index2, targets, batch_size=2)
+        gen = GraphBatchGenerator(feature, bond, glob_features, index1, index2, targets,
+                                  batch_size=2)
         data = gen[0]
         self.assertListEqual(list(data[0][0].shape), [1, 5, 4])
         self.assertListEqual(list(data[0][1].shape), [1, 3, 5])
@@ -34,6 +36,13 @@ class TestGraph(unittest.TestCase):
         self.assertListEqual(list(data[0][3].shape), [1, 3])
         self.assertListEqual(list(data[0][4].shape), [1, 3])
         self.assertListEqual(list(data[1].shape), [1, 2, 1])
+
+        # Make sure it still functions if a target is not provided
+        gen = GraphBatchGenerator(feature, bond, glob_features, index1, index2, batch_size=2)
+
+        data = gen[0]
+        self.assertEqual(7, len(data))  # Should only be the inputs
+        self.assertListEqual(list(data[0].shape), [1, 5, 4])
 
     def test_graph_batch_distance_converter(self):
         feature = [np.random.normal(size=(3, 4)), np.random.normal(size=(2, 4))]


### PR DESCRIPTION
Lets you still use the generator functionality when making predictions in bulk