### PR TITLE
Metrics in MEGNetModel

### DIFF
--- a/megnet/models.py
+++ b/megnet/models.py
@@ -351,7 +351,7 @@ class MEGNetModel(GraphModel):
         l2_coef: (float or None) l2 regularization parameter
         is_classification: (bool) whether it is a classification task
         loss: (object or str) loss function
-        metrics: (str or list of str) metrics to monitor during training
+        metrics: (list or dict) List or dictionary of Keras metrics to be evaluated by the model during training and testing
         dropout: (float) dropout rate
         graph_converter: (object) object that exposes a "convert" method for structure to graph conversion
         target_scaler: (object) object that exposes a "transform" and "inverse_transform" methods for transforming the target values

--- a/megnet/models.py
+++ b/megnet/models.py
@@ -138,7 +138,6 @@ class GraphModel:
             val_generator = self._create_generator(*val_inputs,
                                                    batch_size=batch_size)
             steps_per_val = int(np.ceil(len(validation_graphs) / batch_size))
-
             callbacks.extend([ReduceLRUponNan(filepath=filepath,
                                               monitor=monitor,
                                               mode=mode,
@@ -358,6 +357,7 @@ class MEGNetModel(GraphModel):
         target_scaler: (object) object that exposes a "transform" and "inverse_transform" methods for transforming the target values
         optimizer_kwargs (dict): extra keywords for optimizer, for example clipnorm and clipvalue
     """
+
     def __init__(self,
                  nfeat_edge=None,
                  nfeat_global=None,


### PR DESCRIPTION
This pull request introduces the parameter "metrics" in the MEGNet constructor. It is used to define Keras metrics for the Adam-optimizer. This is useful for example if specific metrics need to be monitored during training (for example I used metrics=["mae"] to print the mean absolute error at the end of each epoch through a callback).

If you think this would be generally useful, consider merging this pull request. This commit also removes one unused import, and fixes a small typo.