### PR TITLE
Fix Keras Imports

### DIFF
--- a/megnet/layers/graph/base.py
+++ b/megnet/layers/graph/base.py
@@ -11,8 +11,9 @@ A full GN block has the following computation steps
 """
 
 from keras.engine import Layer
-from keras.layers import initializers, regularizers, constraints
+from keras import regularizers, constraints, initializers
 from megnet import activations
+
 
 class GraphNetworkLayer(Layer):
     """

--- a/megnet/layers/readout/set2set.py
+++ b/megnet/layers/readout/set2set.py
@@ -1,7 +1,7 @@
 from keras.engine import Layer
 import keras.backend as kb
 import tensorflow as tf
-from keras.layers import activations, initializers, regularizers, constraints
+from keras import activations, initializers, regularizers, constraints
 from megnet.utils.layer import repeat_with_index
 
 


### PR DESCRIPTION
megnet currently imports the "initializers" and other modules from the "keras.layers" module, which does not work in the current version of Keras. This PR changes the import paths, which makes the code compatible with both the GitHub version and recent versions of Keras. 