### PR TITLE
Fix openbabel imports for openbabel 3.x in utiles/molecule.py

### DIFF
--- a/megnet/utils/molecule.py
+++ b/megnet/utils/molecule.py
@@ -7,8 +7,8 @@ from monty.dev import requires
 from pymatgen.core import Molecule
 
 try:
-    import pybel as pb  # type: ignore
-    import openbabel as ob  # type: ignore
+    from openbabel import pybel as pb  # type: ignore
+    from openbabel import openbabel as ob  # type: ignore
 except ImportError:
     logging.warning(
         "Openbabel is needed for molecule models, " "try 'conda install -c openbabel openbabel' " "to install it"


### PR DESCRIPTION
From https://open-babel.readthedocs.io/en/latest/UseTheLibrary/migration.html:

In OB 3.x, both openbabel.py and pybel.py live within the openbabel
module:

import openbabel as ob
import pybel

from openbabel import openbabel as ob
from openbabel import pybel