### PR TITLE
Avoid running validation set twice

### DIFF
--- a/megnet/models/base.py
+++ b/megnet/models/base.py
@@ -190,6 +190,8 @@ class GraphModel:
                         target_scaler=self.target_scaler,
                     )
                 )
+                val_generator = None  # type: ignore
+                steps_per_val = None  # type: ignore
 
                 if patience is not None:
                     callbacks.append(


### PR DESCRIPTION
If `save_checkpoint`, set `val_generator` and `steps_per_val` to `None`. This avoids issues with accidentally running validation twice -- matching the original behavior before PR #364